### PR TITLE
Encoding param to open function in dashboard

### DIFF
--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -63,7 +63,7 @@ class Dashboard(LoginRequiredMixin, TemplateView):
                         "json",
                         "cu-all.topo.json",
                     ),
-                    encoding="utf-8"
+                    encoding="utf-8",
                 ) as file:
                     file = json.load(file)
                 return JsonResponse(data=file)


### PR DESCRIPTION
Added the parameter encoding="utf-8" to the open function in dashboard view #62