### PR TITLE
Fixed delete message when field is FK of model

### DIFF
--- a/apps/cancer_registry/models.py
+++ b/apps/cancer_registry/models.py
@@ -446,4 +446,4 @@ class Neoplasm(Model):
 
     def __str__(self):
         """A string representation of the model"""
-        return f"{self.patient}"
+        return f"{self.patient} {self.primary_site}"

--- a/apps/cancer_registry/test/test_models.py
+++ b/apps/cancer_registry/test/test_models.py
@@ -12,11 +12,12 @@ class NeoplasmTestCase(TestCase):
             patient__first_name="Test",
             patient__last_name="Test",
             patient__identity_card="123456",
+            primary_site__name="TEST LOCATION",
         )
 
     def test_neoplasm_str(self):
         """Test that neoplasm str method returns the patient name."""
         self.assertEqual(
             str(self.neoplasm),
-            "Test Test (123456)",
+            "Test Test (123456) TEST LOCATION",
         )

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -284,7 +284,11 @@ class BaseDeleteView(
         self.object = self.get_object()
         success_url = self.get_success_url()
         self.object.delete()
-        success_message = self.get_success_message(self.object.__dict__)
+        object_dict = {
+            field.name: str(getattr(self.object, field.name, ""))
+            for field in self.object._meta.fields
+        }
+        success_message = self.get_success_message(object_dict)
         messages.success(self.request, success_message)
         return redirect(success_url)
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -10,7 +10,6 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
-STATICFILES_DIRS = [str(BASE_DIR / "sigipo" / "static" )]
+STATICFILES_DIRS = [str(BASE_DIR / "sigipo" / "static")]
 
 STATIC_ROOT = BASE_DIR / "staticfiles"
-


### PR DESCRIPTION
## Description

- Fixes the error raised when the success message contains a Foreign KEy of the model.
